### PR TITLE
Make named calling convention consistent + net7

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ yzl /ˈiːz(ə)l/ - YAML Zero-Language - F# DSL for YAML
 
 Yzl is a DSL alternative for templating YAML. It was inspired by [Suave HTML View Engine](https://github.com/SuaveIO/suave/blob/master/src/Suave.Experimental/Html.fs).
 
+## Docs
+
+https://queil.github.io/yzl/
+
 ## Example
 
 [Full code here](tests/Example.fs) 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ stages:
     - task: UseDotNet@2
       inputs:
         packageType: 'sdk'
-        version: '6.0.x'
+        version: '7.0.x'
         includePreviewVersions: true
     - task: DotNetCoreCLI@2
       displayName: 'Test'

--- a/src/Yzl/Operators.fs
+++ b/src/Yzl/Operators.fs
@@ -7,7 +7,7 @@ module Operators =
   /// Lift to Yzl Node
   let inline (!) (a:^a) : Node = lift a
   /// Operator for ad-hoc maps creation.
-  let inline (.=) (name: string) (value:^a) : NamedNode = Yzl.named name (value |> lift)
+  let inline (.=) (name: string) (value:^a) : NamedNode = Yzl.named(lift value, name)
   /// Folded string
   let (!>) (value:string) = Folded value
   /// Folded strip string

--- a/src/Yzl/Yzl.fs
+++ b/src/Yzl/Yzl.fs
@@ -85,27 +85,27 @@ module Core =
     and
       [<AbstractClass; Sealed>]
       Yzl =
-        static member named (name:string) (node:Node) = Named(Name name, node)
+        static member named(value: Node, [<CallerMemberName;  Optional; DefaultParameterValue("")>] name: string) = Named(Name name, value)
         /// Creates a named string scalar node from F# string or Yzl.Str
         static member inline str< ^T when ( ^T or Str) : (static member ToYzlString:  ^T ->  Str) >(value: ^T, [<CallerMemberName;  Optional; DefaultParameterValue("")>] name: string) =
           let str : Str = liftString value 
           let yzl = lift str
-          Yzl.named name yzl
+          Yzl.named(yzl, name)
         /// Creates a named integer scalar node
         static member int(value: int, [<CallerMemberName;  Optional; DefaultParameterValue("")>] name: string) =
-          Scalar(Int value) |> Yzl.named name
+          Yzl.named(Scalar(Int value), name)
         /// Creates a named float scalar node
         static member float(value: float, [<CallerMemberName;  Optional; DefaultParameterValue("")>] name: string) =
-          Scalar(Float value) |> Yzl.named name
+          Yzl.named(Scalar(Float value), name)
         /// Creates a named boolean scalar node
         static member boolean(value: bool, [<CallerMemberName;  Optional; DefaultParameterValue("")>] name: string) =
-          Scalar(Bool value) |> Yzl.named name
+          Yzl.named(Scalar(Bool value), name)
         // Creates a named map node
         static member map(value: NamedNode list, [<CallerMemberName;  Optional; DefaultParameterValue("")>] name: string) =
-          MapNode value |> Yzl.named name
+          Yzl.named(MapNode value, name)
         /// Creates a named sequence node
         static member inline seq< 'T when ( 'T or Node) : (static member ToYzl:  'T -> Node)> (value: 'T list, [<CallerMemberName;  Optional; DefaultParameterValue("")>]  name: string) =
-          SeqNode(liftMany value) |> Yzl.named name
+          Yzl.named(SeqNode(liftMany value), name)
         /// Creates an empty node
         /// 
         /// *Typically used when generating YAML tree conditionally to indicate no node should be generated*

--- a/src/Yzl/Yzl.fsproj
+++ b/src/Yzl/Yzl.fsproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>queil</Authors>
     <Description>F# DSL for YAML</Description>
-    <Copyright>2020-2022 © queil</Copyright>
+    <Copyright>2020-2023 © queil</Copyright>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/queil/yzl</RepositoryUrl>
     <FsDocsSourceRepository>https://github.com/queil/yzl/tree/master</FsDocsSourceRepository>

--- a/src/Yzl/Yzl.fsproj
+++ b/src/Yzl/Yzl.fsproj
@@ -10,11 +10,16 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <IncludeSymbols>true</IncludeSymbols>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Yzl.fs" />
     <Compile Include="Operators.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 </Project>

--- a/src/Yzl/Yzl.fsproj
+++ b/src/Yzl/Yzl.fsproj
@@ -20,6 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 </Project>

--- a/tests/Yzl.Tests.Unit.fsproj
+++ b/tests/Yzl.Tests.Unit.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -14,10 +14,10 @@
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AltCover" Version="8.2.820" />
-    <PackageReference Include="Expecto" Version="9.0.0" />
-    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.9.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Include="AltCover" Version="8.*" />
+    <PackageReference Include="Expecto" Version="9.*" />
+    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../src/Yzl/Yzl.fsproj" />

--- a/tests/Yzl.Tests.Unit.fsproj
+++ b/tests/Yzl.Tests.Unit.fsproj
@@ -10,7 +10,6 @@
     <!--<Compile Include="Bindings.fs" />-->
     <Compile Include="Example.fs" />
     <Compile Include="StringsTests.fs" />
-    <Compile Include="Tests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
`Yzl.named` builder function was curried rather than tupled (like all the other ones). Making it consistent makes binding code generation easier.